### PR TITLE
Support for named channels

### DIFF
--- a/lcl-gateway.conf
+++ b/lcl-gateway.conf
@@ -2,16 +2,25 @@
 port=/dev/ttyAMA0
 baud=38400
 
+# Example channel names for RPICT7V1 with default config
+channel_names = NodeID,
+	P1,P2,P3,P4,P5,P6,P7,
+	I1,I2,I3,I4,I5,I6,I7,
+	Vrms
+
+# Only submit these channels (default list)
+channels = P1,P2,P3,P4,Vrms
+
 [emoncms]
 enabled = False
 url = https://emoncms.org/input/post
 apikey = --apikey-from-emoncms-goes-here--
-node = my-rpict
+node = my-rpict7v1
 
 [influxdb]
 enabled = False
 version = 1
-measurement = my-rpict
+measurement = my-rpict7v1
 
 # Parameters for InfluxDB version 1.x
 db = powermon

--- a/lcl-gateway.conf
+++ b/lcl-gateway.conf
@@ -4,14 +4,14 @@ baud=38400
 
 [emoncms]
 enabled = False
-hostname = emoncms.org
+url = https://emoncms.org/input/post
 apikey = --apikey-from-emoncms-goes-here--
-node = 20
+node = my-rpict
 
 [influxdb]
-enabled = True
+enabled = False
 version = 1
-measurement = rpict7v1
+measurement = my-rpict
 
 # Parameters for InfluxDB version 1.x
 db = powermon

--- a/lcl-gateway.py
+++ b/lcl-gateway.py
@@ -5,6 +5,8 @@
 
 import os
 import sys
+import re
+import json
 import logging
 import datetime
 import argparse
@@ -13,6 +15,7 @@ import configparser
 import serial
 import requests
 
+HTTP_TIMEOUT=5
 
 if __name__ == "__main__":
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
@@ -32,7 +35,19 @@ if __name__ == "__main__":
     c = configparser.ConfigParser()
     c.read(args.config)
 
-    baud = c.getint('system','baud')
+    channel_names = c.get('system', 'channel_names')
+    channel_names = re.sub('\s', '', channel_names)
+    channel_names = channel_names.split(',')
+    logging.debug("Channel names: %s", channel_names)
+
+    channels = c.get('system', 'channels', fallback='*')
+    if channels == '*':
+        channels = channel_names.keys()
+    else:
+        channels = re.sub('\s', '', channels)
+        channels = channels.split(',')
+    logging.debug("Channels: %s", channels)
+
     serial_port = c.get('system', 'port')
     if not os.path.exists(serial_port):
         logging.error('Serial port %s not found', serial_port)
@@ -45,14 +60,20 @@ if __name__ == "__main__":
 
     while True:
         try:
+            # Read one line from the source
             data_in = ser.readline()
-            logging.debug(data_in)
+            if not data_in:
+                logging.warning("End of file reached: %s", serial_port)
+                break
+            logging.debug("DataIn: %s", data_in)
+
+            # Parse the data - create a "dict" from channel names and the values
+            data_in = data_in.decode('ascii').strip().split(' ')
+            data_in = map(lambda x: float(x), data_in)
+            data_in = dict(zip(channel_names, data_in))
 
             utcnow = datetime.datetime.utcnow()
             timestamp = utcnow.strftime("%s")
-
-            z = data_in.decode('ascii').strip().split(' ')
-            csv = ','.join(z[1:])
 
             for sect in c.sections():
                 if sect=='emoncms' and c.getboolean(sect,'enabled'):
@@ -60,15 +81,25 @@ if __name__ == "__main__":
                     url = c.get(sect, 'url')
                     node = c.get(sect, 'node')
                     apikey = c.get(sect, 'apikey')
-                    url = "%s?apikey=%s&node=%s&csv=%s" % (url, apikey, node, csv)
-                    logging.debug(url)
-                    r = requests.post(url)
-                    logging.debug(r)
+
+                    data_out = { key: data_in[key] for key in data_in if key in channels }
+
+                    payload = {
+                        "apikey": apikey,
+                        "node": node,
+                        "fulljson": json.dumps(data_out, separators=(',', ':')),
+                    }
+
+                    logging.debug("URL: %s", url)
+                    logging.debug("Payload: %s", payload)
+
+                    r = requests.post(url, params=payload, timeout=HTTP_TIMEOUT)
+                    logging.debug("Result: %d %s", r.status_code, r.reason)
+                    if not r.ok:
+                        logging.warning(r.text)
 
                 if sect=='influxdb' and c.getboolean(sect,'enabled'):
                 #INFLUXDB
-                    t = timestamp
-                    #t = timestamp + '000000000'
                     version = c.get(sect, 'version')
                     url = c.get(sect, 'url')
                     measurement = c.get(sect, 'measurement')
@@ -83,18 +114,19 @@ if __name__ == "__main__":
                         headers = {}
                         params = {'db':db, 'precision':'s'}
 
-                    i = 0
-                    payload = ""
-                    for zz in z[1:]:
-                        i += 1
-                        if zz!="":
-                            payload += "%s,channel=%02d value=%s %s\n" % (measurement, i, zz,t)
+                    payload = []
+                    for channel in channels:
+                        payload.append("%s,channel=%s value=%s %s" % (measurement, channel, data_in[channel], timestamp))
                     logging.debug(payload)
+                    payload_str = "\n".join(payload)
+
                     if version=='2':
-                        r = requests.post(url, headers=headers, params=params, data=payload)
+                        r = requests.post(url, headers=headers, params=params, data=payload_str, timeout=HTTP_TIMEOUT)
                     else:
-                        r = requests.post(url, params=params, data=payload)
-                    logging.debug(r.text)
+                        r = requests.post(url, params=params, data=payload_str, timeout=HTTP_TIMEOUT)
+                    logging.debug("Result: %d %s", r.status_code, r.reason)
+                    if not r.ok:
+                        logging.warning(r.text)
 
                 if sect=='localsave' and c.getboolean(sect,'enabled'):
                 # LOCALSAVE
@@ -112,9 +144,14 @@ if __name__ == "__main__":
 
                     f.write(timestamp+','+csv+'\n')
 
+            logging.debug("---")
+
 
         except KeyboardInterrupt:
             if ls_fileopen:
                 f.close()
             logging.info("Terminating.")
             break
+
+        except requests.exceptions.ConnectionError as e:
+            logging.warning(e)

--- a/lcl-gateway.py
+++ b/lcl-gateway.py
@@ -57,13 +57,12 @@ if __name__ == "__main__":
             for sect in c.sections():
                 if sect=='emoncms' and c.getboolean(sect,'enabled'):
                 #EMONCMS
-                    hostname = c.get(sect, 'hostname')
+                    url = c.get(sect, 'url')
                     node = c.get(sect, 'node')
                     apikey = c.get(sect, 'apikey')
-                    url = "http://%s/input/post?apikey=%s&node=%s&csv=%s" % (hostname, apikey, node, csv)
+                    url = "%s?apikey=%s&node=%s&csv=%s" % (url, apikey, node, csv)
                     logging.debug(url)
                     r = requests.post(url)
-                    #s = urllib2.urlopen(url)
                     logging.debug(r)
 
                 if sect=='influxdb' and c.getboolean(sect,'enabled'):


### PR DESCRIPTION
Hi again,

This PR adds support for named channels. Instead of identifying the channels as 01 .. 15 in emoncms or influxdb we can now give names to the channels, e.g. NodeID,P1,P2,..,I1,I2,.., Vrms (in case of RPICT7V1). This significantly improves the data usability.

At the same time I have added support for selecting the channels to be submitted - in my case I don't yet use CT5..CT7 and don't want to log the current channels at all, so my 'channels' are set to P1,P2,P3,P4,Vrms. That may significantly reduce the data usage in InfluxDB or Localstore.

Also added some other optimisations like persistent connection support for http requests - especially with HTTPS it massively reduces the connection overhead.

Hope you'll like it :)