### PR TITLE
Use local time instead of UTC for the timestamps

### DIFF
--- a/lcl-gateway.py
+++ b/lcl-gateway.py
@@ -102,8 +102,8 @@ if __name__ == "__main__":
             # Filter data by the requested channels
             data_out = { key: data_in[key] for key in data_in if key in channels }
 
-            utcnow = datetime.datetime.utcnow()
-            timestamp = utcnow.strftime("%s")
+            now = datetime.datetime.now()
+            timestamp = now.strftime("%s")
 
             if 'emoncms' in c.sections() and c.getboolean('emoncms', 'enabled'):
             #EMONCMS
@@ -141,7 +141,7 @@ if __name__ == "__main__":
                 logging.debug("URL: %s", url)
                 payload = []
                 for channel in data_out:
-                    payload.append(f"{measurement},channel={channel} value={data_out[channel]} {timestamp}")
+                    payload.append(f"{measurement},channel={channel} value={data_out[channel]}")
                 logging.debug("Payload: %s", payload)
                 payload_str = "\n".join(payload)
 
@@ -149,8 +149,8 @@ if __name__ == "__main__":
 
             if 'localsave' in c.sections() and c.getboolean('localsave', 'enabled'):
             # LOCALSAVE
-                if ls_day != utcnow.day:
-                    ls_day = utcnow.day
+                if ls_day != now.day:
+                    ls_day = now.day
                     ls_dir = c.get('localsave', 'directory')
                     ls_filename = os.path.join(ls_dir, f"lcl-{timestamp}.csv")
                     logging.debug("Localsave file: %s", ls_filename)

--- a/lcl-gateway.service
+++ b/lcl-gateway.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=lcl-gateway Service
+After=network-online.target
+ 
+[Service]
+ExecStart=/usr/local/bin/lcl-gateway.py
+WorkingDirectory=/tmp/
+StandardOutput=file:/tmp/lcl-gateway-stdout.log
+StandardError=file:/tmp/lcl-gateway-stderr.log
+Restart=always
+User=pi
+ 
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Using `utcnow()` makes the timestamps off by the offset from UTC. Use the local time `now()` to produce the correct ones.

Also remove the explicit timestamp from InfluxDB payload and leave it to the server to assign. The InfluxDB server quite likely has a better timekeeping than a small RPi.