### PR TITLE
InfluxDB: Record multiple values in a single row

### DIFF
--- a/lcl-gateway.conf
+++ b/lcl-gateway.conf
@@ -19,12 +19,13 @@ enabled = False
 url = https://emoncms.org/input/post
 #url = http://emonpi/input/post
 apikey = --apikey-from-emoncms-goes-here--
-node = my-rpict7v1
+node = my_rpict7v1
 
 [influxdb]
 enabled = False
 version = 1
-measurement = my-rpict7v1
+measurement = lcl_gateway
+node = my_rpict7v1
 
 # Parameters for InfluxDB version 1.x
 db = powermon

--- a/lcl-gateway.py
+++ b/lcl-gateway.py
@@ -128,6 +128,7 @@ if __name__ == "__main__":
                 version = c.get('influxdb', 'version')
                 url = c.get('influxdb', 'url')
                 measurement = c.get('influxdb', 'measurement')
+                node = c.get('influxdb', 'node')
                 if version =='2':
                     org = c.get('influxdb', 'org')
                     bucket = c.get('influxdb', 'bucket')
@@ -140,14 +141,12 @@ if __name__ == "__main__":
                     params = {'db':db, 'precision':'s'}
 
                 logging.debug("URL: %s", url)
-                payload = []
-                for channel in data_out:
-                    #payload.append(f"{measurement},channel={channel} value={data_out[channel]} {timestamp}")
-                    payload.append(f"{measurement},channel={channel} value={data_out[channel]}")
+                all_values = ",".join([f"{k}={data_out[k]}" for k in data_out])
+                #payload = f"{measurement},node={node} {all_values} {timestamp}" # Use RPi timestamp
+                payload = f"{measurement},node={node} {all_values}"
                 logging.debug("Payload: %s", payload)
-                payload_str = "\n".join(payload)
 
-                post_to_url(session, url, headers=headers, params=params, data=payload_str)
+                post_to_url(session, url, headers=headers, params=params, data=payload)
 
             if 'localsave' in c.sections() and c.getboolean('localsave', 'enabled'):
             # LOCALSAVE


### PR DESCRIPTION
Instead of:
nodename,channel=I1 value=1.23
nodename,channel=I2 value=2.34

Record this instead:
lcl_gateway,node=nodename I1=1.23,I2=2.34

It makes InfluxDB queries waaaay simpler without the need to JOIN multiple rows, e.g. when adding I1 + I2

Here's a script to reshape the old data into the new format: https://gist.github.com/mludvig/61104520274601a94d5cab9028c48b9e